### PR TITLE
Prevent saveOnFail.py from saving too many images

### DIFF
--- a/QIECalibration/finalImages.py
+++ b/QIECalibration/finalImages.py
@@ -1,0 +1,106 @@
+import ROOT as r
+from selectionCuts import *
+import sys
+import glob
+import os
+from shutil import copyfile
+
+r.gROOT.SetBatch(True)
+
+import json
+
+def finalImages(dirName=""):
+    # Initialize Range and Shunt values
+    ranges = [0,1,2,3]
+    shunts = [1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11.5]
+
+
+    # Get list of fit root files
+    fileList = glob.glob(os.path.join(dirName,"fitResults*.root"))
+        
+    for fileName in fileList:
+       
+        # Parse uid from file name
+        
+	uid = fileName[fileName.find("fitResults_")+11:fileName.find(".root")]
+
+    
+        #Create output directory if it doesn't already exist
+        cardDir = os.path.join(dirName,"Submission/Card_%s"%(uid))
+        outDir = os.path.join(dirName,"Submission/Card_%s/plots"%(uid))
+        if not os.path.exists(outDir):
+            os.makedirs(outDir)
+    
+        # Copy other output files to submission directories
+        copyfile(os.path.join(dirName,"fitResults_%s.root"%uid),os.path.join(cardDir,"fitResults_%s.root"%uid))
+        copyfile(os.path.join(dirName,"qieCalibrationParameters_%s.db"%uid),os.path.join(cardDir,"qieCalibrationParameters_%s.db"%uid))
+        copyfile(os.path.join(dirName,"SummaryPlots/%s/%s.json"%(uid,uid)),os.path.join(cardDir,"%s.json"%uid))
+    
+        # Open ROOT file and get the Summary Plots directory
+        rootfile = r.TFile(fileName,"READ")
+        sumDir = rootfile.Get("SummaryPlots")
+        
+        # Initialize vertical lines for pass/fail boundaries
+        hline = r.TLine(0,0,0,0)
+        hline.SetLineColor(2)
+        lline = r.TLine(0,0,0,0)
+        lline.SetLineColor(2)
+        loline = r.TLine(0,0,0,0)
+        loline.SetLineColor(2)
+        holine = r.TLine(0,0,0,0)
+        holine.SetLineColor(2)
+    
+        for sh in shunts:
+            # If shunt 1, loop over all ranges
+            if sh == 1:
+                canv = r.TCanvas("c1","c1",1800,700)
+                canv.Divide(4,2)
+                for ra in ranges:
+                    #Draw Slope Histogram with boundary lines, excluding the drawing if the histogram doesn't exist
+                    canv.cd(ra+1)
+                    if sumDir.GetListOfKeys().Contains("SLOPE_Sh_%s_R_%d"%(str(sh).replace(".",""),ra)):
+                        hist = sumDir.Get("SLOPE_Sh_%s_R_%d"%(str(sh).replace(".",""),ra))
+                        hist.Draw()
+                        hline.DrawLine(failureconds[sh][1],0,failureconds[sh][1],hist.GetMaximum()+1)
+                        hline.Draw("same")
+                        lline.DrawLine(failureconds[sh][0],0,failureconds[sh][0],hist.GetMaximum()+1)
+                        lline.Draw("same")
+                    #Draw Offset Histogram with boundary lines, excluding the drawing if the histogram doesn't exist
+                    canv.cd(ra+1+4)
+                    if sumDir.GetListOfKeys().Contains("OFFSET_Sh_%s-R_%d"%(str(sh).replace(".",""),ra)):
+                        hist = sumDir.Get("OFFSET_Sh_%s-R_%d"%(str(sh).replace(".",""),ra))
+                        hist.Draw()
+                        holine.DrawLine(failcondo[ra][0],0,failcondo[ra][0],hist.GetMaximum()+1)
+                        holine.Draw("same")
+                        loline.DrawLine(-failcondo[ra][0],0,-failcondo[ra][0],hist.GetMaximum()+1)
+                        loline.Draw("same")
+                # Save canvas as png
+                canv.SaveAs(os.path.join(outDir,"Shunt_%s_%s.png"%(str(sh).replace(".",""),uid)))
+            # If not shunt 1, only loop over ranges 0 and 1
+            else:
+                canv = r.TCanvas("c1","c1",900,700)
+                canv.Divide(2,2)
+                for ra in [0,1]:
+                    #Draw Slope Histogram with boundary lines, excluding the drawing if the histogram doesn't exist
+                    canv.cd(ra+1)
+                    if sumDir.GetListOfKeys().Contains("SLOPE_Sh_%s_R_%d"%(str(sh).replace(".",""),ra)):
+                        hist = sumDir.Get("SLOPE_Sh_%s_R_%d"%(str(sh).replace(".",""),ra))
+                        hist.Draw()
+                        hline.DrawLine(failureconds[sh][1],0,failureconds[sh][1],hist.GetMaximum()+1)
+                        hline.Draw("same")
+                        lline.DrawLine(failureconds[sh][0],0,failureconds[sh][0],hist.GetMaximum()+1)
+                        lline.Draw("same")
+                    #Draw Offset Histogram with boundary lines, excluding the drawing if the histogram doesn't exist
+                    canv.cd(ra+1+2)
+                    if sumDir.GetListOfKeys().Contains("OFFSET_Sh_%s-R_%d"%(str(sh).replace(".",""),ra)):
+                        hist = sumDir.Get("OFFSET_Sh_%s-R_%d"%(str(sh).replace(".",""),ra))
+                        hist.Draw()
+                        holine.DrawLine(failcondo[ra][0],0,failcondo[ra][0],hist.GetMaximum()+1)
+                        holine.Draw("same")
+                        loline.DrawLine(-failcondo[ra][0],0,-failcondo[ra][0],hist.GetMaximum()+1)
+                        loline.Draw("same")
+                canv.SaveAs(os.path.join(outDir,"Shunt_%s_%s.png"%(str(sh).replace(".",""),uid)))
+                        
+        rootfile.Close()
+if __name__ == '__main__':
+    finalImages(sys.argv[1])

--- a/QIECalibration/saveOnFail.py
+++ b/QIECalibration/saveOnFail.py
@@ -8,6 +8,7 @@ import fnmatch
 import numpy
 from array import array
 from pprint import pprint
+from collections import Counter
 
 gROOT.SetBatch(True)
 
@@ -17,158 +18,160 @@ except NameError:
     from utils import Quiet
 
 def saveTGraph(rootFile,shuntMult,i_range,qieNumber,i_capID,verbose=False):
-            tGraphDir = rootFile.Get("LinadcVsCharge")
-            fitLineDir = rootFile.Get("fitLines")
-            fName = rootFile.GetName()
-            gName = "LinADCvsfC_%s_range_%s_shunt_%s_capID_%s_linearized"%(qieNumber,i_range,str("%.1f"%shuntMult).replace(".","_"),i_capID)
+    tGraphDir = rootFile.Get("LinadcVsCharge")
+    fitLineDir = rootFile.Get("fitLines")
+    fName = rootFile.GetName()
+    outputDir = os.path.dirname(fName)
 
-            graph = tGraphDir.Get(gName)
 
-            fitLine = fitLineDir.Get("fit_%s"%gName)
+    gName = "LinADCvsfC_%s_range_%s_shunt_%s_capID_%s_linearized"%(qieNumber,i_range,str("%.1f"%shuntMult).replace(".","_"),i_capID)
 
-            qieInfo = ""
+    graph = tGraphDir.Get(gName)
 
-            qieBarcode = ""
-            qieUniqueID = ""
+    fitLine = fitLineDir.Get("fit_%s"%gName)
 
-            useCalibrationMode = True
-            outputDir = os.path.dirname(fName)
-            saveName = outputDir
-            if saveName[-1]!='/':
-                saveName += '/'
-            saveName += "plots"
-            
-            if qieBarcode != "":
-                qieInfo += ", Barcode " + qieBarcode
-            
-            if qieUniqueID != "": 
-                qieInfo += "  UID "+qieUniqueID
-            else:
-                qieUniqueID = "UnknownID"
-            
-            #saveName += qieUniqueID
-            if not os.path.exists(saveName):
-                os.system("mkdir -p %s"%saveName)
-            saveName += "/LinADCvsfC"
-            if qieNumber != 0: 
-                qieInfo += ", QIE " + str(qieNumber)
-                saveName += "_qie"+str(qieNumber)
-            
-            qieInfo += ", CapID " + str(i_capID)
-            saveName += "_range"+str(i_range)
-            saveName += "_capID"+str(i_capID)
-            saveName += "_shunt_"+str(shuntMult).replace(".","_")
-            if not useCalibrationMode: saveName += "_NotCalMode"
-            saveName += ".png"
-            graph.SetTitle("LinADC vs Charge, Range %i Shunt %s%s" % (i_range,str(shuntMult).replace(".","_"),qieInfo))
-            graph.GetYaxis().SetTitle("Lin ADC")
-            graph.GetYaxis().SetTitleOffset(1.2)
-            graph.GetXaxis().SetTitle("Charge fC")
-            xVals = graph.GetX()
-            exVals = graph.GetEX()
-            yVals = graph.GetY()
-            eyVals = graph.GetEY()
-            residuals = []
-            residualErrors = []
-            #residualsY = []
-            #residualErrorsY = []
-            eUp = []
-            eDown = []
-            N = graph.GetN()
-            x = []
-            y = []
-        
-            for i in range(N):
-                residuals.append((yVals[i]-fitLine.Eval(xVals[i]))/max(yVals[i],0.001))
-                xLow = (xVals[i]-exVals[i])
-                xHigh = (xVals[i]+exVals[i])
-                residualErrors.append((eyVals[i]/max(yVals[i],0.001)))
-                x.append(xVals[i])
-        
-        
-            resArray = array('d',residuals)
-            resErrArray = array('d',residualErrors)
-            resErrUpArray = array('d',eUp)
-            resErrDownArray = array('d',eDown)
-            xArray = array('d',x)
-            xErrorsArray = array('d',[0]*len(x))
-            
-            if verbose and i_range == 1:
-                print  "the length of residuals are:",len(resArray)
-                print "the charge length :",len(x)
-        
-            residualGraphX = TGraphErrors(len(x),xArray,resArray, xErrorsArray, resErrArray)
-        
-            residualGraphX.SetTitle("")
-            c1 = TCanvas()
-            p1 = TPad("","",0,0.2,0.9,1)
-            p2 = TPad("","",0.,0.,0.9,0.2)
-            p1.Draw()
-            p2.Draw()
-            p1.SetFillColor(kWhite)
-            p2.SetFillColor(kWhite)
-            p1.cd()
-            p1.SetBottomMargin(0)
-            p1.SetRightMargin(0)
-            p2.SetTopMargin(0)
-            p2.SetBottomMargin(0.3)
-            graph.Draw("ap")
-            fitLine.SetLineColor(kRed)
-            fitLine.SetLineWidth(1)
-            fitLine.Draw("same")
-        
-            xmin = graph.GetXaxis().GetXmin()
-            xmax = graph.GetXaxis().GetXmax()
-            ymin = graph.GetYaxis().GetXmin()
-            ymax = graph.GetYaxis().GetXmax()
-            text = TPaveText(xmin + (xmax-xmin)*.2, ymax - (ymax-ymin)*(.3),xmin + (xmax-xmin)*.6,ymax-(ymax-ymin)*.1)
-            text.SetFillColor(kWhite)
-            text.SetTextSize(0.75*text.GetTextSize())
-            text.SetFillStyle(8000)
-            text.AddText("Slope =  %.4f +- %.4f LinADC/fC" % (fitLine.GetParameter(1), fitLine.GetParError(1)))
-            text.AddText("Offset =  %.2f +- %.2f LinADC" % (fitLine.GetParameter(0), fitLine.GetParError(0)))
-            text.AddText("Chisquare = %e " % (fitLine.GetChisquare()))
-            text.Draw("same")
-        
-        
-            p2.cd()
-            p2.SetTopMargin(0)
-            p2.SetRightMargin(0)
-            p2.SetBottomMargin(0.35)
-            residualGraphX.Draw("ap")
-            zeroLine = TF1("zero","0",-9e9,9e9)
-            zeroLine.SetLineColor(kBlack)
-            zeroLine.SetLineWidth(1)
-            zeroLine.Draw("same")
-        
-            # xmin = xmin-10
-            # xmax = xmax+10
-            #if minCharge < 10: minCharge = -10
-            
-            graph.GetXaxis().SetRangeUser(xmin*0.9, xmax*1.1)
-            graph.GetYaxis().SetRangeUser(ymin*.9,ymax*1.1)
-        
-            residualGraphX.GetXaxis().SetRangeUser(xmin*0.9, xmax*1.1)
-            residualGraphX.GetYaxis().SetRangeUser(-0.1,0.1)
-            residualGraphX.SetMarkerStyle(7)
-            residualGraphX.GetYaxis().SetNdivisions(3,5,0)
-        
-        
-            residualGraphX.GetXaxis().SetLabelSize(0.15)
-            residualGraphX.GetYaxis().SetLabelSize(0.15)
-            residualGraphX.GetYaxis().SetTitle("Residuals")
-            residualGraphX.GetXaxis().SetTitle("Charge (fC)")
-            residualGraphX.GetXaxis().SetTitleSize(0.15)
-            residualGraphX.GetYaxis().SetTitleSize(0.15)
-            residualGraphX.GetYaxis().SetTitleOffset(0.33)
-        
-            p1.cd()
-        
-            if not verbose:
-                Quiet(c1.SaveAs)(saveName)
-            else:
-                c1.SaveAs(saveName)
-            #c1.SaveAs(saveName)
+    qieInfo = ""
+
+    qieBarcode = ""
+    qieUniqueID = ""
+
+    useCalibrationMode = True
+    saveName = outputDir
+    if saveName[-1]!='/':
+        saveName += '/'
+    saveName += "plots"
+    
+    if qieBarcode != "":
+        qieInfo += ", Barcode " + qieBarcode
+    
+    if qieUniqueID != "": 
+        qieInfo += "  UID "+qieUniqueID
+    else:
+        qieUniqueID = "UnknownID"
+    
+    #saveName += qieUniqueID
+    if not os.path.exists(saveName):
+        os.system("mkdir -p %s"%saveName)
+    saveName += "/LinADCvsfC"
+    if qieNumber != 0: 
+        qieInfo += ", QIE " + str(qieNumber)
+        saveName += "_qie"+str(qieNumber)
+    
+    qieInfo += ", CapID " + str(i_capID)
+    saveName += "_range"+str(i_range)
+    saveName += "_capID"+str(i_capID)
+    saveName += "_shunt_"+str(shuntMult).replace(".","_")
+    if not useCalibrationMode: saveName += "_NotCalMode"
+    saveName += ".png"
+    graph.SetTitle("LinADC vs Charge, Range %i Shunt %s%s" % (i_range,str(shuntMult).replace(".","_"),qieInfo))
+    graph.GetYaxis().SetTitle("Lin ADC")
+    graph.GetYaxis().SetTitleOffset(1.2)
+    graph.GetXaxis().SetTitle("Charge fC")
+    xVals = graph.GetX()
+    exVals = graph.GetEX()
+    yVals = graph.GetY()
+    eyVals = graph.GetEY()
+    residuals = []
+    residualErrors = []
+    #residualsY = []
+    #residualErrorsY = []
+    eUp = []
+    eDown = []
+    N = graph.GetN()
+    x = []
+    y = []
+    
+    for i in range(N):
+        residuals.append((yVals[i]-fitLine.Eval(xVals[i]))/max(yVals[i],0.001))
+        xLow = (xVals[i]-exVals[i])
+        xHigh = (xVals[i]+exVals[i])
+        residualErrors.append((eyVals[i]/max(yVals[i],0.001)))
+        x.append(xVals[i])
+    
+    
+    resArray = array('d',residuals)
+    resErrArray = array('d',residualErrors)
+    resErrUpArray = array('d',eUp)
+    resErrDownArray = array('d',eDown)
+    xArray = array('d',x)
+    xErrorsArray = array('d',[0]*len(x))
+    
+    if verbose and i_range == 1:
+        print  "the length of residuals are:",len(resArray)
+        print "the charge length :",len(x)
+    
+    residualGraphX = TGraphErrors(len(x),xArray,resArray, xErrorsArray, resErrArray)
+    
+    residualGraphX.SetTitle("")
+    c1 = TCanvas()
+    p1 = TPad("","",0,0.2,0.9,1)
+    p2 = TPad("","",0.,0.,0.9,0.2)
+    p1.Draw()
+    p2.Draw()
+    p1.SetFillColor(kWhite)
+    p2.SetFillColor(kWhite)
+    p1.cd()
+    p1.SetBottomMargin(0)
+    p1.SetRightMargin(0)
+    p2.SetTopMargin(0)
+    p2.SetBottomMargin(0.3)
+    graph.Draw("ap")
+    fitLine.SetLineColor(kRed)
+    fitLine.SetLineWidth(1)
+    fitLine.Draw("same")
+    
+    xmin = graph.GetXaxis().GetXmin()
+    xmax = graph.GetXaxis().GetXmax()
+    ymin = graph.GetYaxis().GetXmin()
+    ymax = graph.GetYaxis().GetXmax()
+    text = TPaveText(xmin + (xmax-xmin)*.2, ymax - (ymax-ymin)*(.3),xmin + (xmax-xmin)*.6,ymax-(ymax-ymin)*.1)
+    text.SetFillColor(kWhite)
+    text.SetTextSize(0.75*text.GetTextSize())
+    text.SetFillStyle(8000)
+    text.AddText("Slope =  %.4f +- %.4f LinADC/fC" % (fitLine.GetParameter(1), fitLine.GetParError(1)))
+    text.AddText("Offset =  %.2f +- %.2f LinADC" % (fitLine.GetParameter(0), fitLine.GetParError(0)))
+    text.AddText("Chisquare = %e " % (fitLine.GetChisquare()))
+    text.Draw("same")
+    
+    
+    p2.cd()
+    p2.SetTopMargin(0)
+    p2.SetRightMargin(0)
+    p2.SetBottomMargin(0.35)
+    residualGraphX.Draw("ap")
+    zeroLine = TF1("zero","0",-9e9,9e9)
+    zeroLine.SetLineColor(kBlack)
+    zeroLine.SetLineWidth(1)
+    zeroLine.Draw("same")
+    
+    # xmin = xmin-10
+    # xmax = xmax+10
+    #if minCharge < 10: minCharge = -10
+    
+    graph.GetXaxis().SetRangeUser(xmin*0.9, xmax*1.1)
+    graph.GetYaxis().SetRangeUser(ymin*.9,ymax*1.1)
+    
+    residualGraphX.GetXaxis().SetRangeUser(xmin*0.9, xmax*1.1)
+    residualGraphX.GetYaxis().SetRangeUser(-0.1,0.1)
+    residualGraphX.SetMarkerStyle(7)
+    residualGraphX.GetYaxis().SetNdivisions(3,5,0)
+    
+    
+    residualGraphX.GetXaxis().SetLabelSize(0.15)
+    residualGraphX.GetYaxis().SetLabelSize(0.15)
+    residualGraphX.GetYaxis().SetTitle("Residuals")
+    residualGraphX.GetXaxis().SetTitle("Charge (fC)")
+    residualGraphX.GetXaxis().SetTitleSize(0.15)
+    residualGraphX.GetYaxis().SetTitleSize(0.15)
+    residualGraphX.GetYaxis().SetTitleOffset(0.33)
+    
+    p1.cd()
+    
+    if not verbose:
+        Quiet(c1.SaveAs)(saveName)
+    else:
+        c1.SaveAs(saveName)
+    #c1.SaveAs(saveName)
 
 def saveOnFail(inputDir):
     fileList = []
@@ -179,6 +182,7 @@ def saveOnFail(inputDir):
     for fName in fileList:
         rootFile = TFile.Open(fName.replace(".json",".root").replace("70/","70/fitResults_"),'read')
 
+        outputDir = os.path.dirname(fName)
         ###################################################
         # Values to get from json file
         ###################################################
@@ -216,6 +220,37 @@ def saveOnFail(inputDir):
         for failModeFit in jsonFile['Comments']['Poor fit']:
             if failModeFit not in failModeList:
                 failModeList.append(failModeFit)
+
+        qieList = [x[2] for x in failModeList]
+        qieCounter = Counter(qieList)
+
+        tooManyErrors = []
+        for badChip in qieCounter:
+        #    print badChip,": ",qieCounter[badChip]
+            if qieCounter[badChip] >= 16:
+                saveName = outputDir
+                if saveName[-1]!='/':
+                    saveName += '/'
+                saveName += "plots"
+                saveName += "/LinADCvsfC"
+                if qieNumber != 0: 
+                    saveName += "_qie"+str(badChip)
+                
+                saveName += ".png"
+                canv = TCanvas("c")
+                text = TPaveText(0.05,0.1,0.95,0.8)
+                text.AddText("QIE %s Contains More Than 16 Errors!"%badChip)
+                text.GetListOfLines().Last().SetTextColor(2)
+                if verbose:
+                    print "%s QIE %s Contains More That 16 Errors!"%(qieUniqueID,badChip)
+                text.Draw()
+                canv.Update()
+                if not verbose:
+                    Quiet(canv.SaveAs)(saveName)
+                else:
+                    canv.SaveAs(saveName)
+                failModeList = [failMode for failMode in failModeList if failMode[2] != badChip]
+
 
         for failMode in failModeList:
 


### PR DESCRIPTION
If a qie chip has more than 16 failure modes, only save one image containing the text "QIE # Contains Too Many Errors!". This has a worse case scenario of saving 269 images, which should not kill the database/website server.